### PR TITLE
Testing for filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ _yardoc
 doc/
 
 test.rb
+Gemfile.lock
+.ruby-version
+.ruby-gemset

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test.rb
 Gemfile.lock
 .ruby-version
 .ruby-gemset
+spec/support/webpurify_api_key.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/lib/web_purify/methods/filters.rb
+++ b/lib/web_purify/methods/filters.rb
@@ -63,10 +63,10 @@ module WebPurify
         :text   => text
       }
       parsed = WebPurify::Request.query(@request_base, @query_base, params.merge(options))
-      if parsed[:expletive]
+      if parsed[:expletive].is_a?(String)
         return [] << parsed[:expletive]
       else
-        return []
+        return parsed.fetch(:expletive, [])
       end
     end
     

--- a/spec/fixtures/vcr/WebPurify_Filters/check/safe_text_returns_false.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check/safe_text_returns_false.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.check&text=safe%20text
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Mon, 27 Apr 2015 22:29:03 GMT
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.check","format":"rest","found":"0","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Mon, 27 Apr 2015 22:27:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check/text_with_a_URL_returns_false_by_default.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check/text_with_a_URL_returns_false_by_default.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.check&text=text%20with%20www.example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Mon, 27 Apr 2015 22:31:53 GMT
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.check","format":"rest","found":"0","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Mon, 27 Apr 2015 22:31:03 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check/text_with_a_URL_when_URLs_are_prohibited_returns_true.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check/text_with_a_URL_when_URLs_are_prohibited_returns_true.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.check&slink=1&text=text%20with%20www.example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Mon, 27 Apr 2015 22:31:38 GMT
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.check","format":"rest","found":"1","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Mon, 27 Apr 2015 22:31:03 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check/text_with_a_phone_number_returns_false_by_default.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check/text_with_a_phone_number_returns_false_by_default.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.check&text=text%20with%20555-555-5555
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Mon, 27 Apr 2015 22:35:37 GMT
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.check","format":"rest","found":"0","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Mon, 27 Apr 2015 22:34:25 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check/text_with_a_phone_number_when_phone_numbers_are_prohibited_returns_true.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check/text_with_a_phone_number_when_phone_numbers_are_prohibited_returns_true.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.check&sphone=1&text=text%20with%20555-555-5555
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Mon, 27 Apr 2015 22:35:14 GMT
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.check","format":"rest","found":"1","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Mon, 27 Apr 2015 22:34:25 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check/text_with_an_email_returns_false_by_default.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check/text_with_an_email_returns_false_by_default.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.check&text=text%20with%20name@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Mon, 27 Apr 2015 22:30:40 GMT
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.check","format":"rest","found":"0","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Mon, 27 Apr 2015 22:29:50 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check/text_with_an_email_when_emails_are_prohibited_returns_true.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check/text_with_an_email_when_emails_are_prohibited_returns_true.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.check&semail=1&text=text%20with%20name@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Mon, 27 Apr 2015 22:30:26 GMT
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.check","format":"rest","found":"1","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Mon, 27 Apr 2015 22:29:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check/text_with_profanity_returns_true.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check/text_with_profanity_returns_true.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.check&text=text%20with%20damn
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Mon, 27 Apr 2015 22:29:03 GMT
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.check","format":"rest","found":"1","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Mon, 27 Apr 2015 22:27:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check_count/no_profanities_returns_0.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check_count/no_profanities_returns_0.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.checkcount&text=safe%20text
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Tue, 28 Apr 2015 14:33:26 GMT
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.checkcount","format":"rest","found":"0","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 14:32:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check_count/one_profanity_returns_1.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check_count/one_profanity_returns_1.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.checkcount&text=text%20with%20damn
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Tue, 28 Apr 2015 14:33:26 GMT
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.checkcount","format":"rest","found":"1","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 14:32:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/check_count/two_profanities_returns_2.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/check_count/two_profanities_returns_2.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.checkcount&text=text%20with%20damn%20and%20hell
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Tue, 28 Apr 2015 14:34:04 GMT
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.checkcount","format":"rest","found":"2","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 14:32:51 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/replace/safe_text_returns_the_text_with_no_changes.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/replace/safe_text_returns_the_text_with_no_changes.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.replace&replacesymbol=*&text=safe%20text
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Tue, 28 Apr 2015 14:45:43 GMT
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.replace","format":"rest","found":"0","text":"safe
+        text","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 14:44:53 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/replace/text_with_profanity_returns_the_text_with_profanities_replaced_by_symbols.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/replace/text_with_profanity_returns_the_text_with_profanities_replaced_by_symbols.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.replace&replacesymbol=*&text=text%20with%20damn%20and%20hell
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Tue, 28 Apr 2015 15:04:27 GMT
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.replace","format":"rest","found":"2","text":"text
+        with **** and ****","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 15:03:14 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/return/no_profanities_returns_an_empty_array.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/return/no_profanities_returns_an_empty_array.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.return&text=safe%20text
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Tue, 28 Apr 2015 15:04:05 GMT
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.return","format":"rest","found":"0","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 15:03:29 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/return/one_profanity_returns_an_array_with_one_profanity.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/return/one_profanity_returns_an_array_with_one_profanity.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.return&text=text%20with%20damn
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Tue, 28 Apr 2015 15:04:15 GMT
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.return","format":"rest","found":"1","expletive":"damn","api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 15:03:30 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr/WebPurify_Filters/return/two_profanities_returns_an_array_with_two_profanities.yml
+++ b/spec/fixtures/vcr/WebPurify_Filters/return/two_profanities_returns_an_array_with_two_profanities.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api1.webpurify.com/services/rest/?api_key=<WEBPURIFY_API_KEY>&format=json&method=webpurify.live.return&text=text%20with%20damn%20and%20hell
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api1.webpurify.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Powered-By:
+      - HPHP
+      Date:
+      - Tue, 28 Apr 2015 15:04:43 GMT
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: '{"rsp":{"@attributes":{"stat":"ok"},"method":"webpurify.live.return","format":"rest","found":"2","expletive":["hell","damn"],"api_key":"<WEBPURIFY_API_KEY>"}}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 15:03:30 GMT
+recorded_with: VCR 2.9.3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require 'web_purify'
+
+Dir['spec/support/**/*.rb'].each { |f| require_relative "../#{f}" }

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,30 @@
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = File.join("spec", "fixtures", "vcr")
+  c.hook_into :webmock
+  c.filter_sensitive_data("<WEBPURIFY_API_KEY>") { ENV["WEBPURIFY_API_KEY"] }
+end
+
+# This wraps RSpec examples with vcr: true in a VCR#use_cassette block and creates
+# a cassette using the name of the example the first time an HTTP request is made.
+module VcrHelper
+  def with_vcr_cassette example, name = nil, options = {}, &block
+    name ||= default_cassette_name_for_example(example)
+    VCR.use_cassette name, options, &block
+  end
+
+  def default_cassette_name_for_example(example)
+    example.full_description.sub(/\s/, '/').sub('#', '/').gsub(/[^\w\/]+/, "_")
+  end
+end
+
+RSpec.configuration.include VcrHelper, vcr: true
+
+RSpec.configure do |config|
+  config.around(:each, vcr: true) do |example|
+    with_vcr_cassette(example) do
+      example.call
+    end
+  end
+end

--- a/spec/web_purify/methods/filters_spec.rb
+++ b/spec/web_purify/methods/filters_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe WebPurify::Filters, "#check", vcr: true do
+  let(:client) { WebPurify::Client.new(ENV["WEBPURIFY_API_KEY"]) }
+  let(:options) { {} }
+  subject { client.check(text, options) }
+
+  context "safe text" do
+    let(:text) { "safe text" }
+
+    it "returns false" do
+      expect(subject).to eq(false)
+    end
+  end
+
+  context "text with profanity" do
+    let(:text) { "text with damn" }
+
+    it "returns true" do
+      expect(subject).to eq(true)
+    end
+  end
+
+  context "text with an email" do
+    let(:text) { "text with name@example.com"}
+
+    it "returns false by default" do
+      expect(subject).to eq(false)
+    end
+
+    context "when emails are prohibited" do
+      let(:options) { { semail: 1 } }
+
+      it "returns true" do
+        expect(subject).to eq(true)
+      end
+    end
+  end
+
+  context "text with a phone number" do
+    let(:text) { "text with 555-555-5555" }
+
+    it "returns false by default" do
+      expect(subject).to eq(false)
+    end
+
+    context "when phone numbers are prohibited" do
+      let(:options) { { sphone: 1 } }
+
+      it "returns true" do
+        expect(subject).to eq(true)
+      end
+    end
+  end
+
+  context "text with a URL" do
+    let(:text) { "text with www.example.com" }
+
+    it "returns false by default" do
+      expect(subject).to eq(false)
+    end
+
+    context "when URLs are prohibited" do
+      let(:options) { { slink: 1 } }
+
+      it "returns true" do
+        expect(subject).to eq(true)
+      end
+    end
+  end
+
+end

--- a/spec/web_purify/methods/filters_spec.rb
+++ b/spec/web_purify/methods/filters_spec.rb
@@ -122,3 +122,33 @@ describe WebPurify::Filters, "#replace", vcr: true do
   end
 
 end
+
+describe WebPurify::Filters, "#return", vcr: true do
+  let(:client) { WebPurify::Client.new(ENV["WEBPURIFY_API_KEY"]) }
+  subject { client.return(text) }
+
+  context "no profanities" do
+    let(:text) { "safe text" }
+
+    it "returns an empty array" do
+      expect(subject).to eq([])
+    end
+  end
+
+  context "one profanity" do
+    let(:text) { "text with damn" }
+
+    it "returns an array with one profanity" do
+      expect(subject).to eq(["damn"])
+    end
+  end
+
+  context "two profanities" do
+    let(:text) { "text with damn and hell" }
+
+    it "returns an array with two profanities" do
+      expect(subject).to contain_exactly("damn", "hell")
+    end
+  end
+
+end

--- a/spec/web_purify/methods/filters_spec.rb
+++ b/spec/web_purify/methods/filters_spec.rb
@@ -70,3 +70,33 @@ describe WebPurify::Filters, "#check", vcr: true do
   end
 
 end
+
+describe WebPurify::Filters, "#check_count", vcr: true do
+  let(:client) { WebPurify::Client.new(ENV["WEBPURIFY_API_KEY"]) }
+  subject { client.check_count(text) }
+
+  context "no profanities" do
+    let(:text) { "safe text" }
+
+    it "returns 0" do
+      expect(subject).to eq(0)
+    end
+  end
+
+  context "one profanity" do
+    let(:text) { "text with damn" }
+
+    it "returns 1" do
+      expect(subject).to eq(1)
+    end
+  end
+
+  context "two profanities" do
+    let(:text) { "text with damn and hell" }
+
+    it "returns 2" do
+      expect(subject).to eq(2)
+    end
+  end
+
+end

--- a/spec/web_purify/methods/filters_spec.rb
+++ b/spec/web_purify/methods/filters_spec.rb
@@ -100,3 +100,25 @@ describe WebPurify::Filters, "#check_count", vcr: true do
   end
 
 end
+
+describe WebPurify::Filters, "#replace", vcr: true do
+  let(:client) { WebPurify::Client.new(ENV["WEBPURIFY_API_KEY"]) }
+  subject { client.replace(text, "*") }
+
+  context "safe text" do
+    let(:text) { "safe text" }
+
+    it "returns the text with no changes" do
+      expect(subject).to eq(text)
+    end
+  end
+
+  context "text with profanity" do
+    let(:text) { "text with damn and hell" }
+
+    it "returns the text with profanities replaced by symbols" do
+      expect(subject).to eq("text with **** and ****")
+    end
+  end
+
+end

--- a/web_purify.gemspec
+++ b/web_purify.gemspec
@@ -13,9 +13,11 @@ Gem::Specification.new do |s|
   s.summary     = %q{A RubyGem for interfacing with the WebPurify API.}
   s.description = %q{A RubyGem for interfacing with the WebPurify API.}
 
-  s.add_development_dependency "rspec", "~>2.5.0"
-  
   s.add_dependency "json"
+
+  s.add_development_dependency "rspec", "~> 3.2.0"
+  s.add_development_dependency "vcr"
+  s.add_development_dependency "webmock"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This adds testing for the filter methods using RSpec and VCR. I did make one functionality change in WebPurify::Filters#return. Previously, it returned a two-dimensional array if more than one profanity was found--I changed it to always return a one-dimensional array, whether 0, 1, or multiple profanities were found.
